### PR TITLE
Makefile - install ensures lib and bin exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ dungeon: $(OBJS) dtextc.dat
 	$(CC) $(CFLAGS) -o zork $(OBJS) $(LIBS)
 
 install: zork dtextc.dat
+	mkdir -p $(BINDIR) $(LIBDIR)
 	cp zork $(BINDIR)
 	cp dtextc.dat $(LIBDIR)
 


### PR DESCRIPTION
Before we `cp` the zork and dtextc.dat files we mkdir the lib and bin path. Hopefully, this is sane from the Makefile perspective. 
Created to address the comment here: https://github.com/Homebrew/homebrew-core/pull/14681#discussion_r123882825
