### PR TITLE
Makefile - Also make manpages directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ dungeon: $(OBJS) dtextc.dat
 	$(CC) $(CFLAGS) -o zork $(OBJS) $(LIBS)
 
 install: zork dtextc.dat
-	mkdir -p $(BINDIR) $(LIBDIR)
+	mkdir -p $(BINDIR) $(LIBDIR) $(MANDIR)/man6
 	cp zork $(BINDIR)
 	cp dtextc.dat $(LIBDIR)
 	cp dungeon.6 $(MANDIR)/man6/


### PR DESCRIPTION
This PR also configures `make install` to attempt to make the entire path for storing the man page prior to cp'ing it. 

