### PR TITLE
Fix reused integers from being optimized out

### DIFF
--- a/np1.c
+++ b/np1.c
@@ -27,7 +27,7 @@ logical vbflag;
     const integer r50wal = 36852;
 
     /* System generated locals */
-    integer ret_val, i__1, i__2;
+    volatile integer ret_val, i__1, i__2;
 
     /* Local variables */
     integer i, j, adj;


### PR DESCRIPTION
# Summary

Fix segfault when reused integers are optimized out by compiler


# Background

This patch was contributed by @Jan200101 to fix a [reported segfault](https://bugzilla.redhat.com/show_bug.cgi?id=1833823) in the Fedora package from compiler optimizations. We can carry a custom patch for the Fedora-specific package, but we generally try to work with an upstream so everyone may benefit from a change, not only Fedora.

This change was tested with a local scratch build on at least two Fedora machines. It is likely other distributions could face similar issues when upgrading their compilers.


# Details

It is a simple change, and honestly I am not a C developer. If you really want an explanation, @Jan200101 could probably provide one if you ask.

If this change is accepted, it would be helpful to cut a new release with a git tag. This will trigger the first step in the Fedora package distribution process for shipping an update. 🙂 


# Outcome

Support optimizations from newer versions of compilers without segfaulting after opening the mailbox