### PR TITLE
correctly fix invalid read from pvoc array

### DIFF
--- a/np1.c
+++ b/np1.c
@@ -27,7 +27,7 @@ logical vbflag;
     const integer r50wal = 36852;
 
     /* System generated locals */
-    volatile integer ret_val, i__1, i__2;
+    integer ret_val, i__1, i__2;
 
     /* Local variables */
     integer i, j, adj;
@@ -55,7 +55,7 @@ logical vbflag;
     pv_1.p2 = 0;
 
     buzlnt = 20;
-    prplnt = 48;
+    prplnt = 45;
     dirlnt = 75;
 /* SPARSE, PAGE 8 */
 


### PR DESCRIPTION
follow up to #14 after I had been urged to look into this more

the real problem was caused by prplnt, the integer used to define the size of the pvoc array, being off by 3 causing an invalid read
I recreated the environment that caused the crash from #14 and couldn't replicate anymore with this fix

the value of `prplnt` could have been intentional considering the place where its used increments by 3 every iteration

I came to the wrong conclusion before because I was debugging the rpm package which compiled with -O2