### PR TITLE
Fix compile error on Linux and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,57 +1,8 @@
 # Makefile for dungeon
 
-# Where to install the program
-BINDIR = /usr/games
-
-# Where to install the data file
-DATADIR = /usr/games/lib
-
-# Where to install the man page
-MANDIR = /usr/share/man
-
-# The dungeon program provides a ``more'' facility which tries to
-# figure out how many rows the terminal has.  Several mechanisms are
-# supported for determining this; the most common one has been left
-# uncommented.  If you have trouble, especially when linking, you may
-# have to select a different option.
-
-# more option 1: use the termcap routines.  On some systems the LIBS
-# variable may need to be set to -lcurses.  On some it may need to
-# be /usr/lib/termcap.o.  These options are commented out below.
-LIBS = -ltermcap
-TERMFLAG =
-# LIBS = -lcurses
-# LIBS = /usr/lib/termcap.o
-
-# more option 2: use the terminfo routines.  On some systems the LIBS
-# variable needs to be -lcursesX, but probably all such systems support
-# the termcap routines (option 1) anyhow.
-# LIBS = -lcurses
-# TERMFLAG = -DMORE_TERMINFO
-
-# more option 3: assume all terminals have 24 rows
-# LIBS =
-# TERMFLAG = -DMORE_24
-
-# more option 4: don't use the more facility at all
-# LIBS =
-# TERMFLAG = -DMORE_NONE
-
-# End of more options
-
-# Uncomment the following line if you want to have access to the game
-# debugging tool.  This is invoked by typing "gdt".  It is not much
-# use except for debugging.
-GDTFLAG = -DALLOW_GDT
-
-# Compilation flags
-CFLAGS = -g #-static
-# On SCO Unix Development System 3.2.2a, the const type qualifier does
-# not work correctly when using cc.  The following line will cause it
-# to not be used and should be uncommented.
-# CFLAGS= -O -Dconst=
-
-##################################################################
+# Configuration. If the default configuration does not work on your machine,
+# modify the environment variables in this file:
+include config.mk
 
 # Source files
 CSRC =	actors.c ballop.c clockr.c demons.c dgame.c dinit.c dmain.c\

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,52 @@
+# The dungeon program provides a ``more'' facility which tries to
+# figure out how many rows the terminal has.  Several mechanisms are
+# supported for determining this; the most common one has been left
+# uncommented.  If you have trouble, especially when linking, you may
+# have to select a different option.
+
+# more option 1: use terminfo's database. termcap has long been superceded
+# by terminfo and this is now the most likely option on modern machines.
+LIBS = -lcurses
+#TERMFLAG = -DMORE_TERMINFO # On older machines this may need uncommenting.
+
+# more option 2: use the termcap routines.  On some systems the LIBS
+# variable may need to be set to -lcurses.  On some it may need to
+# be /usr/lib/termcap.o.  These options are commented out below.
+# LIBS = -ltermcap
+# TERMFLAG =
+# LIBS = -lcurses
+# LIBS = /usr/lib/termcap.o
+
+# more option 3: assume all terminals have 24 rows
+# LIBS =
+# TERMFLAG = -DMORE_24
+
+# more option 4: don't use the more facility at all
+# LIBS =
+# TERMFLAG = -DMORE_NONE
+
+# End of more options
+
+# Uncomment the following line if you want to have access to the game
+# debugging tool.  This is invoked by typing "gdt".  It is not much
+# use except for debugging.
+# GDTFLAG = -DALLOW_GDT
+
+# Where to install the program
+BINDIR = /usr/games
+
+# Where to install the data file
+DATADIR = /usr/games/lib
+
+# Where to install the man page
+MANDIR = /usr/share/man
+
+# Compilation flags
+CFLAGS = -g #-static # musl libc systems may want -static.
+# On SCO Unix Development System 3.2.2a, the const type qualifier does
+# not work correctly when using cc.  The following line will cause it
+# to not be used and should be uncommented.
+# CFLAGS= -O -Dconst=
+
+##################################################################
+

--- a/local.c
+++ b/local.c
@@ -2,6 +2,10 @@
 
 #include "funcs.h"
 
+#ifdef __linux__
+#include <unistd.h> /* provides getuid() */
+#endif
+
 #ifdef __AMOS__
 #include <moncal.h>
 #endif


### PR DESCRIPTION
There is a fatal error in local.c that occurs in Linux but not Darwin/MacOS (unsure if other platforms are affected) if `unistd.h` is not included.

I also went ahead and moved all of the parts of the Makefile that vary per end-user to a new config.mk file. Additionally I bumped `terminfo` to the top of the list over `termcap` because that has been the more common option for a very long time now.