### PR TITLE
add preprocessor to use plain curses header, correct setupterm prototype

### DIFF
--- a/supp.c
+++ b/supp.c
@@ -114,9 +114,13 @@ extern int tgetnum P((const char *));
 
 #ifdef MORE_TERMINFO
 
+#ifdef PLAIN_CURSES
+#include <curses.h>
+#else
 #include <cursesX.h>
+#endif
 #include <term.h>
-extern void setupterm P((const char *, int, int));
+extern int setupterm P((const char *, int, int *));
 
 #else /* ! MORE_TERMINFO */
 


### PR DESCRIPTION
The source code was originally designed to be used with X/Open Curses which had a unqiue header to differentiate from all the incompatible curses implementations including the one that was shipped with Ultrix.

These days ncurses and PDcurses implement X/Open Curses compatible interfaces so everything is interoperable however on Ultrix curses.h and cursesX.h are two different headers which conflict so a preprocessor is needed to pick the desired header.

The setupterm prototype had subtle problems, the return value was always implicitly defined to be int but since it is never used it was set to void and the third argument has always been an int* but this is not an issue at runtime.

tested with:
`make LIBS=-lcurses TERMFLAG="-DMORE_TERMINFO -DPLAIN_CURSES"`