### PR TITLE
👷 ci: Add GitHub Actions build and smoke test pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Restore compiler cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ matrix.cc }}-${{ hashFiles('*.c', '*.h', 'Makefile') }}
+          restore-keys: |
+            ccache-${{ matrix.cc }}-
+
+      - name: Install dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq libncurses-dev ccache
+
+      - name: Build
+        run: |
+          ccache --zero-stats
+          make clean
+          make CC="ccache ${{ matrix.cc }}" LIBS="-lncurses" -j$(nproc)
+          ccache --show-stats
+
+      - name: Verify binary
+        run: test -x ./zork
+
+      - name: Smoke test
+        run: |
+          output=$(printf "LOOK\nQUIT\nY\n" | timeout 10 ./zork 2>&1)
+          echo "$output"
+          echo "--- Verifying expected output ---"
+          echo "$output" | grep -q "Welcome to Dungeon"
+          echo "$output" | grep -q "white house"
+          echo "$output" | grep -q "mailbox"
+          echo "$output" | grep -q "game is over"
+          echo "--- Smoke test passed ---"


### PR DESCRIPTION
This project has had no automated testing or CI for its entire history. As a code-preservation project, manual play-testing was the only way to verify changes didn't break the game. This commit adds a GitHub Actions pipeline that proves compilation succeeds and the game starts correctly on every push and pull request.

The pipeline tests with both GCC and Clang via a build matrix, catching compiler-specific issues in parallel. The Makefile defaults to `-ltermcap` which is unavailable as a standalone library on the CI runner; the workflow overrides with `LIBS="-lncurses"` which provides termcap compatibility through `ncurses`.

A smoke test pipes LOOK, QUIT, Y into the game and asserts the welcome banner, opening room description, and clean exit message all appear. This catches initialization failures, data file corruption, and command loop regressions without modifying any game source.

Compilation caching via `ccache` keeps repeat builds fast. Each compiler gets its own cache keyed on source file content hashes, with prefix- based restore, so a single changed file still benefits from cached results for the other 32 compilation units. Concurrency controls cancel in-progress runs when new commits land on the same ref.

No game source files are modified — the CI infrastructure is entirely additive and lives in `.github/`.